### PR TITLE
Improvements to .sh script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,97 @@
 # autoinc-semver
+
 Automatic semantic version number generator
 
-Usage: semver-build.bat e.g. ```semver-build.bat ./version.h```
+- [Usage](#usage)
+- [update-boiler-version](#update-boiler-version)
+- [update-version.py](#update-versionpy)
 
-Just use the prebuild option of vscode call this script to increment the build number. 
-It will automatically find the major.minor.patch+build values and then auto increment the buildnumber. 
+---
+
+## Usage
+
+- **Mac/Linux**
+
+  ```shell
+  ./semver-incr-build.sh ./version.h
+  ```
+
+- **Windows**
+
+  ```shell
+  semver-incr-build.bat ./version.h
+  ```
+
+Just use the prebuild option of vscode call this script to increment the build number.
+It will automatically find the major.minor.patch+build values and then auto increment the buildnumber.
 Also it will timestamp date and time of the buildprocess into the file.
-This script generates version numbers folloing the Semantic Version 2.0 (See http://semver.org)
+This script generates version numbers folloing the Semantic Version 2.0 (See <http://semver.org>)
 
 It creates an Adruino C/C++ compatible file you can include in your aduino sketch to reflect the version number.
 
-The content of the file will look something like this: 
+The content of the file will look something like this:
+
 ```C
-#define _VERSION_MAJOR 0 
+#pragma once
+
+// The version number conforms to semver.org format
+#define _VERSION_MAJOR 0
 #define _VERSION_MINOR 0
-#define _VERSION_PATCH 1 
-#define _VERSION_BUILD 41 
-#define _VERSION_DATE 04-07-2020 
-#define _VERSION_TIME 14:40:18 
-#define _VERSION_ONLY 0.0.1 
-#define _VERSION_NOBUILD 0.0.1 (04-07-2020) 
-#define _VERSION 2.0.3+41 (04-07-2020)
+#define _VERSION_PATCH 0
+#define _VERSION_BUILD 1
+#define _VERSION_PRERELEASE
+#define _VERSION_DATE "16-07-2020"
+#define _VERSION_TIME "18:31:48"
+#define _SEMVER_CORE "0.0.0"
+#define _SEMVER_BUILD "0.0.0+1"
+#define _VERSION_FULL "0.0.0+1"
+#define _VERSION_NOBUILD "0.0.0 (16-07-2020)"
+#define _VERSION "0.0.0+1 (16-07-2020)"
+// The version information is created automatically, more information here: https://github.com/rvdbreemen/autoinc-semver
 ```
 
-The MAJOR, MINOR and PATCH are set manually. BUILD will auto-increment each time you call the script. TIME and DATE are set to the moment in time you call the script. The VERSION_ONLY, VERSION_NOBUILD and VERSION are all constructed from the previous set of parameters. 
+The MAJOR, MINOR and PATCH are set manually. BUILD will auto-increment each time you call the script. TIME and DATE are set to the moment in time you call the script. The VERSION_ONLY, VERSION_NOBUILD and VERSION are all constructed from the previous set of parameters.
 
-There are two versions of this script, one that can be used for Windows (batch) and one for Linux/MacOS (bash). 
+There are two versions of this script, one that can be used for Windows (batch) and one for Linux/MacOS (bash).
 
 The use pre build scripts with VSCode and the Aduino plugin is [explained here](https://github.com/Microsoft/vscode-arduino#options).  
 Simply goto the arduino.json and add the following line to the options:  
-``"prebuild": "<script path>/semver-incr-build ./version.h"``
+`"prebuild": "<script path>/semver-incr-build ./version.h"`
 
-How to use the Arduino IDE the pre-build hooks, [read this Arduino documentation](https://arduino.github.io/arduino-cli/platform-specification/#pre-and-post-build-hooks-since-arduino-ide-165). And [this topic](https://forum.arduino.cc/index.php?topic=586019.0) on the hooks on the forum. 
+How to use the Arduino IDE the pre-build hooks, [read this Arduino documentation](https://arduino.github.io/arduino-cli/platform-specification/#pre-and-post-build-hooks-since-arduino-ide-165). And [this topic](https://forum.arduino.cc/index.php?topic=586019.0) on the hooks on the forum.
 
 It comes down to this:
-1. Open the ```platform.txt``` in this directory: ```C:\Users\<username>\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.7.1```
-2. Then add the following line to execute the script on each build:   
-```recipe.hooks.sketch.prebuild.0.pattern=D:\<directory location of script>\autoinc-semver\semver-incr-build.bat {build.source.path}\version.h``` 
 
+1. Open the `platform.txt` in this directory: `C:\Users\<username>\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.7.1`
+2. Then add the following line to execute the script on each build:
+   `recipe.hooks.sketch.prebuild.0.pattern=D:\<directory location of script>\autoinc-semver\semver-incr-build.bat {build.source.path}\version.h`
 
-# update-boiler-version
+## update-boiler-version
+
 To update my source files, I created another script. It looks for the signature of the "version" boiler plate
 and then replaces it with the version found in the version header file. Before it makes any changes, it commits
 to github. Then it updates all the relevant source files to the current version. To finally commit and tag with
 the current version.
 
-To modify it to your needs, just go and change it in the file itself. If you like to live dangerous, then you 
-could do without github (not recommended). Otherwise, just enjoy the magic of auto-semver and this script. 
+To modify it to your needs, just go and change it in the file itself. If you like to live dangerous, then you
+could do without github (not recommended). Otherwise, just enjoy the magic of auto-semver and this script.
 
 If anyone enjoys writting in bash, please do a pull request to get it added.
-
 
 Change the scripts to your needs, it's up to you now.
 
 This script is released to enjoy!
 
-# update-version.py
-2024-04-17 After a couple of years I could not get the update-boiler-version.bat to work. Not sure what to do 
+## update-version.py
+
+2024-04-17 After a couple of years I could not get the update-boiler-version.bat to work. Not sure what to do
 I realized that maybe co-pilot & chatgpt could help me convert to Python. After about 1 hour of work and feeding
 my original batch script first. I created this script, it seems to do about the same as the batch file did before.
-It updates the relevant version information in the file headers of each relevant file. 
+It updates the relevant version information in the file headers of each relevant file.
 
-Enjoy the script... 
+Enjoy the script...
 
-```
+```plain
 =================================================================================
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Automatic semantic version number generator
 
 - [Usage](#usage)
+- [Using PlatformIO](#using-platformio)
 - [update-boiler-version](#update-boiler-version)
 - [update-version.py](#update-versionpy)
 
@@ -65,6 +66,51 @@ It comes down to this:
 1. Open the `platform.txt` in this directory: `C:\Users\<username>\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.7.1`
 2. Then add the following line to execute the script on each build:
    `recipe.hooks.sketch.prebuild.0.pattern=D:\<directory location of script>\autoinc-semver\semver-incr-build.bat {build.source.path}\version.h`
+
+## Using PlatformIO
+
+This library can be included in your `platformio.ini` file's `lib_deps` by pointing to the GitHub repo url.
+
+**☣️ Note that you should always use a verified tag after the `#` to help prevent supply-chain attacks! You can also use a trusted commit's SHA instead of a tag.**
+
+```ini
+# platformio.ini
+
+lib_deps =
+  https://github.com/rvdbreemen/autoinc-semver#0.1.9
+```
+
+To run the versioning script on pre-build, for example, use [`extra_scripts`](https://docs.platformio.org/en/latest/projectconf/sections/env/options/advanced/extra_scripts.html) as such:
+
+```ini
+# platformio.ini
+
+extra_scripts =
+  pre:pre_extra_script.py
+```
+
+Then, create a new `pre_extra_script.py` in your PlatformIO repo's root and use [pre/post actions](https://docs.platformio.org/en/latest/scripting/actions.html) and more.
+
+```python
+# pre_extra_script.py
+
+Import("env")
+
+print("\n🐍 Running extra scripts ...\n")
+
+BOARD_LIBDEPS_DIR = env["PROJECT_LIBDEPS_DIR"] + "/" + env["BOARD"]
+SEMVER_INCR_BUILD_SCRIPT = BOARD_LIBDEPS_DIR + "/semver-incr-build/semver-incr-build.sh"
+
+# Pre-build action
+def pre_build(source, target, env):
+    print("\n🐍 pre_build\n")
+
+    # Make executable first
+    env.Execute(f"chmod +x {SEMVER_INCR_BUILD_SCRIPT}")
+    env.Execute(f"{SEMVER_INCR_BUILD_SCRIPT} src/version.h")
+
+env.AddPreAction("$PROGPATH", pre_build)
+```
 
 ## update-boiler-version
 

--- a/library.json
+++ b/library.json
@@ -1,0 +1,25 @@
+{
+  "name": "semver-incr-build",
+  "version": "0.1.8",
+  "description": "Automatic semantic version number generator",
+  "keywords": "c++, arduino, platformio, esp32, esp8266, semver, build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rvdbreemen/autoinc-semver"
+  },
+  "authors": [
+    {
+      "name": "Robert van den Breemen (@rvdbreemen)",
+      "email": "robert@vandenbreemen.net",
+      "url": "https://github.com/rvdbreemen/autoinc-semver",
+      "maintainer": true
+    }
+  ],
+  "license": "MIT",
+  "homepage": "https://www.helloworld.org/",
+  "dependencies": {
+    "ownername/print": "~1.3.0"
+  },
+  "frameworks": "*",
+  "platforms": "*"
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "semver-incr-build",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Automatic semantic version number generator",
   "keywords": "c++, arduino, platformio, esp32, esp8266, semver, build",
   "repository": {
@@ -17,9 +17,7 @@
   ],
   "license": "MIT",
   "homepage": "https://www.helloworld.org/",
-  "dependencies": {
-    "ownername/print": "~1.3.0"
-  },
+  "dependencies": {},
   "frameworks": "*",
   "platforms": "*"
 }

--- a/semver-incr-build.sh
+++ b/semver-incr-build.sh
@@ -76,20 +76,31 @@ echo "Increment build $BUILD"
 echo "Version is: $VERSION"
 
 # write the version numbers out to the file
-echo "//The version number conforms to semver.org format">$file
-echo "#define _VERSION_MAJOR ${MAJOR}">>$file
-echo "#define _VERSION_MINOR $MINOR">>$file
-echo "#define _VERSION_PATCH $PATCH">>$file
-echo "#define _VERSION_BUILD $BUILD">>$file
-echo "#define _VERSION_DATE \"$TIMESTAMP\"">>$file
-echo "#define _VERSION_DATE_ISO \"$TIMESTAMP_ISO\"">>$file
-echo "#define _VERSION_TIME \"$Hour:$Minute:$Second\"">>$file
-echo "#define _VERSION_ONLY \"$MAJOR.$MINOR.$PATCH\"">>$file
-echo "#define _VERSION_NOBUILD \"$MAJOR.$MINOR.$PATCH ($TIMESTAMP)\"">>$file
-echo "#define _VERSION_NOBUILD_ISO \"$MAJOR.$MINOR.$PATCH ($TIMESTAMP_ISO)\"">>$file
-echo "#define _VERSION \"$VERSION ($TIMESTAMP)\"">>$file
-echo "#define _VERSION_ISO \"$VERSION ($TIMESTAMP_ISO)\"">>$file
-echo "//The version information is created automatically, more information here: https://github.com/rvdbreemen/autoinc-semver">>$file
+
+# remove the file before re-creating it.
+if [ -f "$file" ]; then
+    rm "$file"
+fi
+
+{
+  echo "#pragma once"
+  echo ""
+  echo "//The version number conforms to semver.org format"
+  echo "#define _VERSION_MAJOR ${MAJOR}"
+  echo "#define _VERSION_MINOR $MINOR"
+  echo "#define _VERSION_PATCH $PATCH"
+  echo "#define _VERSION_BUILD $BUILD"
+  echo "#define _VERSION_DATE \"$TIMESTAMP\""
+  echo "#define _VERSION_DATE_ISO \"$TIMESTAMP_ISO\""
+  echo "#define _VERSION_TIME \"$Hour:$Minute:$Second\""
+  echo "#define _VERSION_ONLY \"$MAJOR.$MINOR.$PATCH\""
+  echo "#define _VERSION_NOBUILD \"$MAJOR.$MINOR.$PATCH ($TIMESTAMP)\""
+  echo "#define _VERSION_NOBUILD_ISO \"$MAJOR.$MINOR.$PATCH ($TIMESTAMP_ISO)\""
+  echo "#define _VERSION \"$VERSION ($TIMESTAMP)\""
+  echo "#define _VERSION_ISO \"$VERSION ($TIMESTAMP_ISO)\""
+  echo ""
+  echo "//The version information is created automatically, more information here: https://github.com/rvdbreemen/autoinc-semver"
+} > "$file"
 
 # clear version numbers
 MAJOR=
@@ -98,9 +109,9 @@ PATCH=
 BUILD=
 VERSION=
 TIMESTAMP=
-echo $VERSION
+echo "$VERSION"
 
-exit 1
+exit 0
 
 # MIT License
 #

--- a/version.h
+++ b/version.h
@@ -2,16 +2,16 @@
 
 //The version number conforms to semver.org format
 #define _VERSION_MAJOR 0
-#define _VERSION_MINOR 0
-#define _VERSION_PATCH 0
-#define _VERSION_BUILD 2
-#define _VERSION_DATE "02/07/2024"
-#define _VERSION_DATE_ISO "2024-07-02"
-#define _VERSION_TIME "21:59:20"
-#define _VERSION_ONLY "0.0.0"
-#define _VERSION_NOBUILD "0.0.0 (02/07/2024)"
-#define _VERSION_NOBUILD_ISO "0.0.0 (2024-07-02)"
-#define _VERSION "0.0.0+2 (02/07/2024)"
-#define _VERSION_ISO "0.0.0+2 (2024-07-02)"
+#define _VERSION_MINOR 1
+#define _VERSION_PATCH 9
+#define _VERSION_BUILD 3
+#define _VERSION_DATE "03/07/2024"
+#define _VERSION_DATE_ISO "2024-07-03"
+#define _VERSION_TIME "00:47:20"
+#define _VERSION_ONLY "0.1.9"
+#define _VERSION_NOBUILD "0.1.9 (03/07/2024)"
+#define _VERSION_NOBUILD_ISO "0.1.9 (2024-07-03)"
+#define _VERSION "0.1.9+3 (03/07/2024)"
+#define _VERSION_ISO "0.1.9+3 (2024-07-03)"
 
 //The version information is created automatically, more information here: https://github.com/rvdbreemen/autoinc-semver

--- a/version.h
+++ b/version.h
@@ -1,14 +1,17 @@
+#pragma once
+
 //The version number conforms to semver.org format
 #define _VERSION_MAJOR 0
-#define _VERSION_MINOR 0  
+#define _VERSION_MINOR 0
 #define _VERSION_PATCH 0
-#define _VERSION_BUILD 1
-#define _VERSION_PRERELEASE 
-#define _VERSION_DATE "16-07-2020"
-#define _VERSION_TIME "18:31:48"
-#define _SEMVER_CORE "0.0.0"
-#define _SEMVER_BUILD "0.0.0+1"
-#define _VERSION_FULL "0.0.0+1"
-#define _VERSION_NOBUILD "0.0.0 (16-07-2020)"
-#define _VERSION "0.0.0+1 (16-07-2020)"
+#define _VERSION_BUILD 2
+#define _VERSION_DATE "02/07/2024"
+#define _VERSION_DATE_ISO "2024-07-02"
+#define _VERSION_TIME "21:59:20"
+#define _VERSION_ONLY "0.0.0"
+#define _VERSION_NOBUILD "0.0.0 (02/07/2024)"
+#define _VERSION_NOBUILD_ISO "0.0.0 (2024-07-02)"
+#define _VERSION "0.0.0+2 (02/07/2024)"
+#define _VERSION_ISO "0.0.0+2 (2024-07-02)"
+
 //The version information is created automatically, more information here: https://github.com/rvdbreemen/autoinc-semver


### PR DESCRIPTION
Thanks for the code, @rvdbreemen!  I'm using PlatformIO, so I'm starting to make some updates in my fork, and I'd like to share them back.

- [x] Explicitly removed version.h before re-creating it.
- [x] Added `#pragma once` to version.h so it's not included multiple times.
- [x] Grouped the echo commands which write version.h so they make a single file write for performance (see [SC2129 – ShellCheck Wiki](https://www.shellcheck.net/wiki/SC2129).  
- [x] Return with exit code 0 so that calling scripts don't throw an error.
- [x] Readme tweaks, including docs on how to use this lib with PlatformIO.
- [x] Added `library.json` so that the project can be imported from GitHub in Arduino IDE and PlatformIO.

## Questions

- [x] Would you like me to tag this with a new release, or could you please do it _(e.g., `0.1.9`)_?  [It's important to use tagged releases](https://github.com/rvdbreemen/autoinc-semver/pull/5/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74) when importing into an Arduino or PlatformIO project, as importing straight from `main` branch creates the security risk of a supply-chain attack.
